### PR TITLE
Add contact search to API

### DIFF
--- a/src/controllers/ContactController.php
+++ b/src/controllers/ContactController.php
@@ -64,14 +64,14 @@ class ContactController {
         $query_params = [];
         parse_str($_SERVER['QUERY_STRING'], $query_params);
 
-        $search = $query_params['search'] ?? null;
+        $query = $query_params['query'] ?? null;
 
-        if ($search === null) {
-            $this->sendJsonResponse(['error' => "Query 'search' term not provided"], 400);
+        if ($query === null) {
+            $this->sendJsonResponse(['error' => "Search query term 'query' not provided"], 400);
             return;
         }
 
-        $contacts = $this->repository->getContactsByName($user_id, $search);
+        $contacts = $this->repository->getContactsByName($user_id, $query);
 
         if ($contacts !== null) {
             $this->sendJsonResponse(['contacts' => $contacts], 200);

--- a/src/controllers/ContactController.php
+++ b/src/controllers/ContactController.php
@@ -41,7 +41,14 @@ class ContactController {
                 $this->sendJsonResponse(['error' => 'Method not allowed.'], 405);
                 return;
             }
-        } else if ($request_uri == 'search') {
+        } else if (str_starts_with($request_uri, 'search')) {
+            if ($request_method == 'GET') {
+                $this->searchContacts($user_id, $data);
+                return;
+            } else {
+                $this->sendJsonResponse(['error' => 'Method not allowed.'], 405);
+                return;
+            }
             return;
         } else if (is_numeric($request_uri)) {
             $contact_id = intval($request_uri);
@@ -51,10 +58,28 @@ class ContactController {
             $this->sendJsonResponse(['error' => 'Not found.'], 404);
             return;
         }
+    }
 
+    public function searchContacts(int $user_id): void {
+        $query_params = [];
+        parse_str($_SERVER['QUERY_STRING'], $query_params);
+
+        $search = $query_params['search'] ?? null;
+
+        if ($search === null) {
+            $this->sendJsonResponse(['error' => "Query 'search' term not provided"], 400);
+            return;
+        }
+
+        $contacts = $this->repository->getContactsByName($user_id, $search);
+
+        if ($contacts !== null) {
+            $this->sendJsonResponse(['contacts' => $contacts], 200);
+        } else {
+            $this->sendJsonResponse(['error' => 'Could not search contacts'], 500);
+        }
     }
     
-
     public function getContacts(int $user_id): void {
         $contacts = $this->repository->getContactsForId($user_id);
 

--- a/src/repositories/ContactRepository.php
+++ b/src/repositories/ContactRepository.php
@@ -22,12 +22,18 @@ class ContactRepository {
     }
     
     // May need to create seperate functions for first and last name if LIKE emptyString returns all contacts
-    public function getContactsByName(int $user_id, string $searched_first_name, string $searched_last_name): ?array {
-        $stmt = 'SELECT contact_id, first_name, last_name, email FROM ContactInfo WHERE created_by_id = :user_id 
+    public function getContactsByName(int $user_id, string $query): ?array {
+        $stmt = 'SELECT * FROM ContactInfo WHERE created_by_id = :user_id 
             AND (first_name LIKE :searched_first_name% OR last_name LIKE :searched_last_name%)';
 
+        $params = [
+            ':user_id' => $user_id,
+            ':searched_first_name' => $query,
+            ':searched_last_name' => $query,
+        ];
+
         try {
-            $result = $this->db->run($stmt, ['user_id' => $user_id]);
+            $result = $this->db->run($stmt, $params);
         } catch (PDOException $e) {
             return null;
         }

--- a/src/repositories/ContactRepository.php
+++ b/src/repositories/ContactRepository.php
@@ -24,12 +24,15 @@ class ContactRepository {
     // May need to create seperate functions for first and last name if LIKE emptyString returns all contacts
     public function getContactsByName(int $user_id, string $query): ?array {
         $stmt = 'SELECT * FROM ContactInfo WHERE created_by_id = :user_id 
-            AND (first_name LIKE :searched_first_name% OR last_name LIKE :searched_last_name%)';
+            AND (first_name LIKE :first_name OR last_name LIKE :last_name OR email LIKE :email)';
 
         $params = [
             ':user_id' => $user_id,
-            ':searched_first_name' => $query,
-            ':searched_last_name' => $query,
+            // Need to do this three times 
+            // because PDO can't bind the same parameter multiple times...
+            ':first_name' => $query . '%',
+            ':last_name' => $query . '%',
+            ':email' => $query . '%',
         ];
 
         try {


### PR DESCRIPTION
Implement contact searching using `GET` on `/api/contact/search?query={search_query}`

Searches over first name, last name, and email on the database.

Tested that proper error messages/codes returned with missing query parameter and incorrect method.