### PR TITLE
Add contact operations

### DIFF
--- a/src/controllers/ContactController.php
+++ b/src/controllers/ContactController.php
@@ -52,8 +52,20 @@ class ContactController {
             return;
         } else if (is_numeric($request_uri)) {
             $contact_id = intval($request_uri);
-            echo $contact_id;
-            return;
+            switch($request_method) {
+            case 'GET':
+                $this->getContactById($user_id);
+                return;
+            case 'PUT':
+                $this->updateContact($user_id, $data);
+                return;
+            case 'DELETE':
+                $this->deleteContact($user_id, $data);
+                return;
+            default:
+                $this->sendJsonResponse(['error' => 'Method not allowed.'], 405);
+                return;
+            }
         } else {
             $this->sendJsonResponse(['error' => 'Not found.'], 404);
             return;

--- a/src/controllers/ContactController.php
+++ b/src/controllers/ContactController.php
@@ -125,11 +125,12 @@ class ContactController {
     }
 
     public function getContactById(int $contact_id): void {
-        $contact = $this->repository->getContactById($contact_id);
-
         try {
+            $contact = $this->repository->getContactById($contact_id);
             $this->sendJsonResponse(['contact' => $contact], 200);
-        } catch (PDOException $e) {
+        } catch(ContactNotFoundException $e) {
+            $this->sendJsonResponse(['error' => $e->getMessage()], 400);
+        } catch(PDOException $e) {
             $this->sendJsonResponse(['error' => 'Could not get contact'], 500);
         }
     }

--- a/src/controllers/ContactController.php
+++ b/src/controllers/ContactController.php
@@ -125,11 +125,6 @@ class ContactController {
     }
 
     public function getContactById(int $contact_id): void {
-        if ($contact_id === null) {
-            $this->sendJsonResponse(['error' => 'No contact_id sent'], 400);
-            return;
-        }
-
         $contact = $this->repository->getContactById($contact_id);
 
         if ($contact !== null) {
@@ -146,38 +141,28 @@ class ContactController {
             return;
         }
 
-        if ($contact_id === null) {
-            $this->sendJsonResponse(['error' => 'No contact_id sent'], 400);
-            return;
-        }
-
         //potential problem line here for null values, double check behavior when trying to only update one value
         if (!isset($data['firstName']) || !isset($data['lastName']) || !isset($data['email'])) {
-            $this->sendJsonResponse(['error' => 'firstName, lastName, or email must be set'], 400);
+            $this->sendJsonResponse(['error' => 'firstName, lastName, and email must be set'], 400);
             return;
         }
 
         $result = $this->repository->updateContact($contact_id, $data['firstName'], $data['lastName'], $data['email']);
 
         if ($result !== null) {
-            // TODO: Should this return the full contact? - Copied comment as still may apply
-            $this->sendJsonResponse(['id' => $result], 201);
+            // Return 204 (no content) on success.
+            http_response_code(204);
         } else {
             $this->sendJsonResponse(['error' => 'Could not update contact'], 400);
         }
     }
 
     public function deleteContact(int $contact_id): void {
-        if ($contact_id === null) {
-            $this->sendJsonResponse(['error' => 'No contact_id sent'], 400);
-            return;
-        }
-
         $result = $this->repository->deleteContact($contact_id);
 
         if ($result !== null) {
-            // Proper response may not be exactly this
-            $this->sendJsonResponse(['success' => $result], 204);
+            // Return 204 (no content) on success.
+            http_response_code(204);
         } else {
             $this->sendJsonResponse(['error' => 'Could not delete contact'], 500);
         }

--- a/src/controllers/ContactController.php
+++ b/src/controllers/ContactController.php
@@ -52,6 +52,12 @@ class ContactController {
             return;
         } else if (is_numeric($request_uri)) {
             $contact_id = intval($request_uri);
+
+            if(!$this->repository->checkUserIdOwnsContact($user_id, $contact_id)) {
+                $this->sendJsonResponse(['error' => 'Access forbidden.'], 403);
+                return;
+            }
+
             switch($request_method) { //Note that none of these functions verify if the contact belongs to the right user
             case 'GET':
                 $this->getContactById($contact_id);

--- a/src/controllers/ContactController.php
+++ b/src/controllers/ContactController.php
@@ -97,11 +97,10 @@ class ContactController {
             return;
         }
 
-        $contacts = $this->repository->getContactsByName($user_id, $query);
-
-        if ($contacts !== null) {
+        try { 
+            $contacts = $this->repository->getContactsByName($user_id, $query);
             $this->sendJsonResponse(['contacts' => $contacts], 200);
-        } else {
+        } catch(PDOException $e) {
             $this->sendJsonResponse(['error' => 'Could not search contacts'], 500);
         }
     }

--- a/src/controllers/ContactController.php
+++ b/src/controllers/ContactController.php
@@ -54,13 +54,13 @@ class ContactController {
             $contact_id = intval($request_uri);
             switch($request_method) { //Note that none of these functions verify if the contact belongs to the right user
             case 'GET':
-                $this->getContactById($data);
+                $this->getContactById($contact_id);
                 return;
             case 'PUT':
-                $this->updateContact($data);
+                $this->updateContact($contact_id, $data);
                 return;
             case 'DELETE':
-                $this->deleteContact($data);
+                $this->deleteContact($contact_id);
                 return;
             default:
                 $this->sendJsonResponse(['error' => 'Method not allowed.'], 405);
@@ -124,19 +124,13 @@ class ContactController {
         }
     }
 
-    public function getContactById(?array $data): void {
-        if ($data === null) {
-            $this->sendJsonResponse(['error' => 'No data sent'], 400);
+    public function getContactById(int $contact_id): void {
+        if ($contact_id === null) {
+            $this->sendJsonResponse(['error' => 'No contact_id sent'], 400);
             return;
         }
 
-        // Not certain if the contact ID would just be stored as 'id' like the schema
-        if (!isset($data['contactId'])) {
-            $this->sendJsonResponse(['error' => 'contactId must be sent'], 400);
-            return;
-        }
-
-        $contact = $this->repository->getContactById($data['contactId']);
+        $contact = $this->repository->getContactById($contact_id);
 
         if ($contact !== null) {
             $this->sendJsonResponse(['contact' => $contact], 200);
@@ -146,19 +140,24 @@ class ContactController {
     }
 
     // Unsure of behavior when handed a null value for one of the parameters, for optional params
-    public function updateContact(?array $data): void {
+    public function updateContact(int $contact_id, ?array $data): void {
         if ($data === null) {
             $this->sendJsonResponse(['error' => 'No data sent'], 400);
             return;
         }
 
-        //potential problem line here for null values, double check behavior when trying to only update one value
-        if (!isset($data['contactId']) || !isset($data['firstName']) || !isset($data['lastName']) || !isset($data['email'])) {
-            $this->sendJsonResponse(['error' => 'contactId, firstName, lastName, or email must be set'], 400);
+        if ($contact_id === null) {
+            $this->sendJsonResponse(['error' => 'No contact_id sent'], 400);
             return;
         }
 
-        $result = $this->repository->updateContact($data['contactId'], $data['firstName'], $data['lastName'], $data['email']);
+        //potential problem line here for null values, double check behavior when trying to only update one value
+        if (!isset($data['firstName']) || !isset($data['lastName']) || !isset($data['email'])) {
+            $this->sendJsonResponse(['error' => 'firstName, lastName, or email must be set'], 400);
+            return;
+        }
+
+        $result = $this->repository->updateContact($contact_id, $data['firstName'], $data['lastName'], $data['email']);
 
         if ($result !== null) {
             // TODO: Should this return the full contact? - Copied comment as still may apply
@@ -168,18 +167,13 @@ class ContactController {
         }
     }
 
-    public function deleteContact(?array $data): void {
-        if ($data === null) {
-            $this->sendJsonResponse(['error' => 'No data sent'], 400);
+    public function deleteContact(int $contact_id): void {
+        if ($contact_id === null) {
+            $this->sendJsonResponse(['error' => 'No contact_id sent'], 400);
             return;
         }
 
-        if (!isset($data['contactId'])) {
-            $this->sendJsonResponse(['error' => 'contactId must be set'], 400);
-            return;
-        }
-
-        $result = $this->repository->deleteContact($data['contactId']);
+        $result = $this->repository->deleteContact($contact_id);
 
         if ($result !== null) {
             // Proper response may not be exactly this

--- a/src/repositories/ContactRepository.php
+++ b/src/repositories/ContactRepository.php
@@ -92,10 +92,6 @@ class ContactRepository {
         ];
 
         $result = $this->db->run($stmt, $params);
-
-        if ($result->rowCount() == 0) {
-            throw new ContactNotFoundException("Contact with ID $contact_id not found");
-        }
     }
 
     // Assuming this function can only be called on a contact accessible by the user, otherwise ID check needed

--- a/src/repositories/ContactRepository.php
+++ b/src/repositories/ContactRepository.php
@@ -1,5 +1,7 @@
 <?php
 
+class ContactNotFoundException extends Exception {}
+
 class ContactRepository {
     private Database $db;
 
@@ -7,20 +9,16 @@ class ContactRepository {
         $this->db = $db;
     }
 
-    public function getContactsForId(int $user_id): ?array {
+    public function getContactsForId(int $user_id): array {
         $stmt = 'SELECT * FROM ContactInfo WHERE created_by_id = :user_id';
 
-        try {
-            $result = $this->db->run($stmt, ['user_id' => $user_id]);
-        } catch (PDOException $e) {
-            return null;
-        }
+        $result = $this->db->run($stmt, ['user_id' => $user_id]);
 
         $contacts = $result->fetchAll();
 
         return $contacts;
     }
-    
+
     // May need to create seperate functions for first and last name if LIKE emptyString returns all contacts
     public function getContactsByName(int $user_id, string $query): ?array {
         $stmt = 'SELECT * FROM ContactInfo WHERE created_by_id = :user_id 
@@ -44,16 +42,15 @@ class ContactRepository {
         return $result->fetchAll();
     }
 
-    public function getContactById(int $contact_id): ?array {
+    public function getContactById(int $contact_id): array {
         $stmt = 'SELECT contact_id, first_name, last_name, email FROM ContactInfo WHERE contact_id = :contact_id';
 
-        try {
-            $result = $this->db->run($stmt, ['contact_id' => $contact_id]);
-        } catch (PDOException $e) {
-            return null;
-        }
+        $result = $this->db->run($stmt, ['contact_id' => $contact_id]);
 
         $contact = $result->fetch();
+        if(!$contact) {
+            throw new ContactNotFoundException("Contact with ID $contact_id not found");
+        }
 
         return $contact;
     }
@@ -69,16 +66,12 @@ class ContactRepository {
             ':email' => $email,
         ];
 
-        try {
-            $result = $this->db->run($stmt, $params);
-            return $this->db->dbConnection->lastInsertId();
-        } catch (PDOException $e) {
-            return null;
-        }
+        $result = $this->db->run($stmt, $params);
+        return $this->db->dbConnection->lastInsertId();
     }
 
     // Assuming this function can only be called on a contact accessible by the user, otherwise ID check needed
-    public function updateContact(int $contact_id, string $first_name, string $last_name, string $email): bool {
+    public function updateContact(int $contact_id, string $first_name, string $last_name, string $email): void {
         $stmt = 'UPDATE ContactInfo SET first_name = :first_name, last_name = :last_name, email = :email 
             WHERE contact_id = :contact_id';
 
@@ -89,25 +82,21 @@ class ContactRepository {
             ':email' => $email,
         ];
 
-        try {
-            $result = $this->db->run($stmt, $params);
-        } catch (PDOException $e) {
-            return false;
-        }
+        $result = $this->db->run($stmt, $params);
 
-        return true;
+        if ($result->rowCount() == 0) {
+            throw new ContactNotFoundException("Contact with ID $contact_id not found");
+        }
     }
 
     // Assuming this function can only be called on a contact accessible by the user, otherwise ID check needed
-    public function deleteContact(int $contact_id): bool {
+    public function deleteContact(int $contact_id): void {
         $stmt = 'DELETE FROM ContactInfo WHERE contact_id = :contact_id';
 
-        try {
-            $result = $this->db->run($stmt, ['contact_id' => $contact_id]);
-        } catch (PDOException $e) {
-            return false;
-        }
+        $result = $this->db->run($stmt, ['contact_id' => $contact_id]);
 
-        return true;
+        if ($result->rowCount() == 0) {
+            throw new ContactNotFoundException("Contact with ID $contact_id not found");
+        }
     }
 }

--- a/src/repositories/ContactRepository.php
+++ b/src/repositories/ContactRepository.php
@@ -44,6 +44,20 @@ class ContactRepository {
         return $result->fetchAll();
     }
 
+    public function getContactById(int $contact_id): ?array {
+        $stmt = 'SELECT contact_id, first_name, last_name, email FROM ContactInfo WHERE contact_id = :contact_id';
+
+        try {
+            $result = $this->db->run($stmt, ['contact_id' => $contact_id]);
+        } catch (PDOException $e) {
+            return null;
+        }
+
+        $contact = $result->fetch();
+
+        return $contact;
+    }
+
     public function createContact(int $created_by_id, string $first_name, string $last_name, string $email): ?int {
         $stmt = 'INSERT INTO ContactInfo (created_by_id, first_name, last_name, email) 
             VALUES (:created_by_id, :first_name, :last_name, :email)';

--- a/src/repositories/ContactRepository.php
+++ b/src/repositories/ContactRepository.php
@@ -33,11 +33,7 @@ class ContactRepository {
             ':email' => $query . '%',
         ];
 
-        try {
-            $result = $this->db->run($stmt, $params);
-        } catch (PDOException $e) {
-            return null;
-        }
+        $result = $this->db->run($stmt, $params);
 
         return $result->fetchAll();
     }

--- a/src/repositories/ContactRepository.php
+++ b/src/repositories/ContactRepository.php
@@ -70,6 +70,19 @@ class ContactRepository {
         return $this->db->dbConnection->lastInsertId();
     }
 
+    public function checkUserIdOwnsContact(int $user_id, int $contact_id): bool {
+        $stmt = 'SELECT created_by_id FROM ContactInfo WHERE contact_id = :contact_id';
+
+        $result = $this->db->run($stmt, ['contact_id' => $contact_id]);
+
+        $contact = $result->fetch();
+        if(!$contact) {
+            throw new ContactNotFoundException("Contact with ID $contact_id not found");
+        }
+
+        return ($contact['created_by_id'] === $user_id);
+    }
+
     // Assuming this function can only be called on a contact accessible by the user, otherwise ID check needed
     public function updateContact(int $contact_id, string $first_name, string $last_name, string $email): void {
         $stmt = 'UPDATE ContactInfo SET first_name = :first_name, last_name = :last_name, email = :email 


### PR DESCRIPTION
Support GET, PUT, and DELETE on `/api/contact/{id}`. Checks if user ID owns contact or if contact ID exists before going through with operation, and returns proper error codes.

Refactored the ContactRepository to throw exceptions, instead of catching them. This way at the caller level (i.e the controller) we can catch them and distinguish between errors.